### PR TITLE
Fixes asyncData execution.

### DIFF
--- a/packages/ream-renderer-vue/app/create-app.js
+++ b/packages/ream-renderer-vue/app/create-app.js
@@ -29,7 +29,7 @@ Vue.mixin({
     }
 
     const namespace = `${this.$route.path}::${name}`
-    const asyncDataStore = process.server ? this.$ssrContext.data.asyncData : window.__REAM__.data.asyncData
+    const asyncDataStore = process.isServer ? this.$ssrContext.data.asyncData : window.__REAM__.data.asyncData
     this.$asyncData = asyncDataStore && asyncDataStore[namespace]
   }
 })


### PR DESCRIPTION
Current bug defaulted this ternary to `false` which kept setting asyncDatastore to the `window` object even on serverside.