### PR TITLE
fixes an issue where dev server will crash if there is no .babelrc

### DIFF
--- a/packages/ream-core/lib/load-config.js
+++ b/packages/ream-core/lib/load-config.js
@@ -6,21 +6,15 @@ const buildConfigChain = require('babel-core/lib/transformation/file/options/bui
 async function loadBabel(load) {
   let babel
 
-  const { useConfig, file } = await load.babel(buildConfigChain)
+  try {
+    const { useConfig, file } = await load.babel(buildConfigChain)
+    babel = useConfig ? { cacheDirectory: true, babelrc: true } : { cacheDirectory: true, babelrc: false };
 
-  if (useConfig) {
-    console.log('> Using external babel configuration')
-    console.log(chalk.dim(`> location: "${tildify(file)}"`))
-    babel = {
-      cacheDirectory: true,
-      babelrc: true
-    }
-  } else {
-    babel = {
-      cacheDirectory: true,
-      babelrc: false
-    }
+  } catch (e) {
+    console.log('Loading babel failed', e);
+    babel = { cacheDirectory: true, babelrc: false }
   }
+
   if (babel.babelrc === false) {
     // Use our default preset when no babelrc was found
     babel.presets = [


### PR DESCRIPTION
This fixes an issues that currently exists, if `load.babel` throws an error, which happens if there is no `.babelrc` file, which will prevent the rest of the function from running and using the default settings. 