### PR TITLE
optimize extracted css assets

### DIFF
--- a/lib/webpack/webpack.config.base.js
+++ b/lib/webpack/webpack.config.base.js
@@ -74,6 +74,13 @@ module.exports = (api, config, type) => {
                 }
               }).apply(compiler)
             }
+          },
+          {
+            apply(compiler) {
+              // eslint-disable-next-line import/no-extraneous-dependencies
+              const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+              new OptimizeCSSAssetsPlugin().apply(compiler)
+            }
           }
         ]
       }

--- a/lib/webpack/webpack.config.base.js
+++ b/lib/webpack/webpack.config.base.js
@@ -228,8 +228,7 @@ module.exports = (api, config, type) => {
           modules,
           sourceMap,
           localIdentName: `[local]_[hash:base64:8]`,
-          importLoaders: 0 + Boolean(api.options.postcss) + Boolean(loader),
-          minimize: isProd
+          importLoaders: 0 + Boolean(api.options.postcss) + Boolean(loader)
         })
 
       // Only use postcss-loader when a config file was found

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "log-update": "^2.3.0",
     "mini-css-extract-plugin": "^0.4.0",
     "object-assign": "^4.1.1",
+    "optimize-css-assets-webpack-plugin": "^4.0.2",
     "postcss-load-config": "^1.2.0",
     "postcss-loader": "^2.1.5",
     "promise-polyfill": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4324,6 +4324,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+last-call-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
+  dependencies:
+    lodash "^4.17.5"
+    webpack-sources "^1.1.0"
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -5266,6 +5273,13 @@ optimist@^0.6.1:
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
+
+optimize-css-assets-webpack-plugin@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-4.0.2.tgz#813d511d20fe5d9a605458441ed97074d79c1122"
+  dependencies:
+    cssnano "^3.10.0"
+    last-call-webpack-plugin "^3.0.0"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"


### PR DESCRIPTION
See https://github.com/ream/ream/issues/83#issuecomment-392822611: this adds additional post-processing / minification of all extracted CSS.

Doing this is [specifically recommended](https://github.com/webpack-contrib/mini-css-extract-plugin#minimizing-for-production) by mini-css-extract-plugin.