### PR TITLE
Fix typo in before-client-render event name

### DIFF
--- a/app/client-entry.js
+++ b/app/client-entry.js
@@ -106,7 +106,7 @@ Vue.mixin({
 // Wait until router has resolved all async before hooks
 // and async components...
 async function main() {
-  event.$emit('before-client-renderer')
+  event.$emit('before-client-render')
 
   if (window.__REAM__.initialData) {
     dataStore.replaceState(window.__REAM__.initialData)


### PR DESCRIPTION
Vuex is currently broken, because it listens for `before-client-render` to restore the state but the app emits `before-client-renderer`.

(On a related note, is Vuex really the only option to pass data from a child route component to the parent having `<router-view />`? Like if I want the child route to explain the parent route component which link to mark as active?) 