### PR TITLE
Pass SSR context to entry

### DIFF
--- a/app/create-app-template.js
+++ b/app/create-app-template.js
@@ -51,7 +51,7 @@ module.exports = api => {
     .join('\n')}
 
   export default context => {
-    const entry = typeof _entry === 'function' ? _entry() : _entry
+    const entry = typeof _entry === 'function' ? _entry(context) : _entry
     let { router, extendRootOptions } = entry
     if (context) {
       context.entry = entry


### PR DESCRIPTION
Passing SSR context to the entry allows to customize app options in runtime (e.g. return different routers). This is backwards compatible.