### PR TITLE
Allow to override .ream outDir location

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ class Ream extends Event {
 
     const defaults = {
       entry: 'index.js',
+      outDir: '.ream',
       fsRoutes: false,
       transpileDependencies: [],
       runtimeCompiler: false,
@@ -404,7 +405,7 @@ class Ream extends Event {
   }
 
   resolveOutDir(...args) {
-    return this.resolveBaseDir('.ream', ...args)
+    return this.resolveBaseDir(this.config.outDir, ...args)
   }
 
   resolveBaseDir(...args) {

--- a/lib/validateConfig.js
+++ b/lib/validateConfig.js
@@ -2,6 +2,7 @@ const joi = require('joi')
 
 const schema = joi.object().keys({
   entry: joi.string(),
+  outDir: joi.string(),
   fsRoutes: joi.alternatives().try([
     joi.object().keys({
       baseDir: joi.string(),


### PR DESCRIPTION
Allow to override `.ream` outDir location. This is useful when `baseDir` is set to e.g. `src/myapp/mywebserver` but a user wants to keep `.ream` in project root (or put it to other arbitrary places such as `/run/ream`)