### PR TITLE
fix targetPath regexp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -212,7 +212,7 @@ class Ream extends Event {
         const html = await this.renderer.renderToString(context)
         const { start, end } = await renderTemplate(context)
         const targetPath = this.resolveOutDir(
-          `generated/${route.replace(/\/?$/, '/index.html')}`
+          `generated/${route.replace(/(\/?$|\/?\?.*$)/, '/index.html')}`
         )
 
         logger.status(emoji.progress, `generating ${route}`)


### PR DESCRIPTION
Directory name includes query params while generating route, but it shouldn't.