### PR TITLE
Feat/static files

### DIFF
--- a/packages/ream/src/server/create-server.ts
+++ b/packages/ream/src/server/create-server.ts
@@ -36,6 +36,9 @@ export async function getRequestHandler(api: Ream) {
     })
   }
 
+  const { createPublicFilesMiddleware } = await require('./public-files-middleware')
+  server.use(createPublicFilesMiddleware(api))
+
   server.use(async (req, res, next) => {
     if (req.path.endsWith('.serverpreload.json')) {
       req.url = req.url.replace(/(\/index)?\.serverpreload\.json/, '')

--- a/packages/ream/src/server/public-files-middleware.ts
+++ b/packages/ream/src/server/public-files-middleware.ts
@@ -1,0 +1,13 @@
+import { join } from 'path'
+import serveStatic from 'serve-static'
+import { ReamServerHandler } from "..";
+import { Ream } from "../node";
+
+export function createPublicFilesMiddleware(api: Ream): ReamServerHandler {
+  const publicFiles = join(api.resolveDir('./'), 'public')
+  const publicHandler = serveStatic(publicFiles)
+
+  return (req, _res, next) => {
+    return publicHandler(req as any, _res as any, next)
+  }
+}

--- a/test/integration/public-files/public/style.css
+++ b/test/integration/public-files/public/style.css
@@ -1,0 +1,3 @@
+body {
+  background: #fafafa;
+}

--- a/test/integration/public-files/routes/index.vue
+++ b/test/integration/public-files/routes/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    The public files work!!
+  </div>
+</template>


### PR DESCRIPTION
### :sparkles: (public-files) serve public directory

All the files inside of `public/` directory at project root are
accessible from the server at the same URI as in the public directory.

eg.
There are two static files present in the public directory at the
following paths:
- `./public/style.css`
- `./public/js/vendor.js`

If the app is hosted at `http://localhost:3000`
then, both of these files will be accessible at the respective URLs
- http://localhost:3000/style.css
- http://localhost:3000/js/vendor.js

Resolves: #24 

P.S.
I know there are some edge cases to handle like if there's a `./public/index.html` and a `./routes/index.vue` then the HTML file overrides ream's route.
I will continue developing further on public files, just checking if the project is active.