### PR TITLE
feat: support page transition

### DIFF
--- a/packages/app/client-entry.js
+++ b/packages/app/client-entry.js
@@ -14,6 +14,20 @@ const router = createRouter({
   scrollBehavior,
 })
 
+router.afterEach((to, from) => {
+  let transition
+  for (const m of to.matched) {
+    const { $$transition } = m.components.default
+    if (typeof $$transition === 'function') {
+      $$transition = $$transition(to, from)
+    }
+    if ($$transition != null) {
+      transition = $$transition
+    }
+  }
+  to.meta.transition = transition
+})
+
 const initialState = reactive(window.INITIAL_STATE)
 
 const { app } = createApp({

--- a/packages/app/client-entry.js
+++ b/packages/app/client-entry.js
@@ -1,6 +1,7 @@
 import 'vite/dynamic-import-polyfill'
 import '/.ream/templates/global-imports.js'
 import { reactive } from 'vue'
+import mitt from 'mitt'
 import { createWebHistory, createRouter } from 'vue-router'
 import { clientRoutes } from '/.ream/templates/shared-exports.js'
 import { createApp } from './create-app'
@@ -20,14 +21,16 @@ const { app } = createApp({
   initialState,
 })
 
+window._ream = {
+  router,
+  initialState,
+  event: mitt(),
+}
+
 router.isReady().then(() => {
   const vm = app.mount('#_ream')
 
-  window._ream = {
-    app: vm,
-    router,
-    initialState,
-  }
+  window._ream.app = vm
 
   router.beforeResolve(getBeforeResolve(vm))
 })

--- a/packages/app/create-app.js
+++ b/packages/app/create-app.js
@@ -1,4 +1,11 @@
-import { h, createSSRApp, isReactive, reactive, computed } from 'vue'
+import {
+  h,
+  createSSRApp,
+  isReactive,
+  reactive,
+  computed,
+  Transition,
+} from 'vue'
 import { createHead, useHead } from '@vueuse/head'
 import { RouterView } from 'vue-router'
 import { RouterLink, useRoutePath } from './'
@@ -39,11 +46,25 @@ export const createApp = ({ router, initialState }) => {
     render() {
       const { notFound, error } = this.preloadResult
 
-      let Component = RouterView
+      let Component
       if (notFound) {
         Component = NotFoundComponent
       } else if (error) {
         Component = ErrorComponent
+      } else {
+        Component = h(RouterView, null, (props) => {
+          return h(
+            Transition,
+            {
+              name: props.route.meta.transitionName || 'page',
+              mode: props.route.meta.transitionMode || 'out-in',
+              onBeforeEnter() {
+                _ream.event.emit('trigger-scroll')
+              },
+            },
+            () => h(props.Component, { key: props.route.path })
+          )
+        })
       }
 
       return h(AppComponent, {}, () => [h(Component)])

--- a/packages/app/create-app.js
+++ b/packages/app/create-app.js
@@ -53,16 +53,26 @@ export const createApp = ({ router, initialState }) => {
         Component = ErrorComponent
       } else {
         Component = h(RouterView, null, (props) => {
-          return h(
-            Transition,
-            {
-              name: props.route.meta.transitionName || 'page',
-              mode: props.route.meta.transitionMode || 'out-in',
-              onBeforeEnter() {
-                _ream.event.emit('trigger-scroll')
-              },
+          const { meta } = props.route
+          const transition =
+            meta.transition === false
+              ? { name: undefined }
+              : typeof meta.transition === 'string'
+              ? { name: meta.transition }
+              : meta.transition || {}
+          const transitionProps = {
+            name: 'page',
+            mode: 'out-in',
+            ...transition,
+            onBeforeEnter() {
+              _ream.event.emit('trigger-scroll')
+              if (transition.onBeforeEnter) {
+                transition.onBeforeEnter()
+              }
             },
-            () => h(props.Component, { key: props.route.path })
+          }
+          return h(Transition, transitionProps, () =>
+            h(props.Component, { key: props.route.path })
           )
         })
       }

--- a/packages/app/lib/scroll-behavior.js
+++ b/packages/app/lib/scroll-behavior.js
@@ -1,13 +1,22 @@
 export const scrollBehavior = (to, from, savedPosition) => {
-  if (to.hash) {
-    return {
-      el: to.hash,
+  return new Promise((resolve) => {
+    const handleScroll = () => {
+      _ream.event.off('trigger-scroll', handleScroll)
+
+      if (to.hash) {
+        return resolve({
+          el: to.hash,
+        })
+      }
+
+      if (savedPosition) {
+        return resolve(savedPosition)
+      }
+
+      resolve({
+        top: 0,
+      })
     }
-  }
-
-  if (savedPosition) {
-    return savedPosition
-  }
-
-  return { top: 0 }
+    _ream.event.on('trigger-scroll', handleScroll)
+  })
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@ream/fetch": "workspace:*",
     "@vueuse/head": "^0.2.3",
-    "vue-router": "^4.0.3",
-    "vue": "^3.0.5"
+    "mitt": "^2.1.0",
+    "vue": "^3.0.5",
+    "vue-router": "^4.0.3"
   }
 }

--- a/packages/ream/src/prepare-files.ts
+++ b/packages/ream/src/prepare-files.ts
@@ -95,6 +95,7 @@ export async function prepareFiles(api: Ream) {
             return `{
             path: "${route.path}",
             ${route.routeName ? `name: "${route.routeName}",` : ``}
+            meta: {},
             component: function() {
               return import("${getRelativePathToTemplatesDir(route.file)}")
                 .then(wrapPage)
@@ -111,6 +112,7 @@ export async function prepareFiles(api: Ream) {
           {
             name: '404',
             path: '/:404(.*)',
+            meta:{},
             component: import.meta.env.DEV ? {
               render() {
                 return h('h1','error: this component should not be rendered')

--- a/packages/ream/src/prepare-files.ts
+++ b/packages/ream/src/prepare-files.ts
@@ -166,6 +166,7 @@ export async function prepareFiles(api: Ream) {
         $$preload: page.preload,
         $$staticPreload: page.staticPreload,
         $$getStaticPaths: page.getStaticPaths,
+        $$transition: page.transition,
         setup: function () {
           return function() {
             var Component = page.default

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,11 +67,13 @@ importers:
     dependencies:
       '@ream/fetch': link:../fetch
       '@vueuse/head': 0.2.3_vue@3.0.5
+      mitt: 2.1.0
       vue: 3.0.5
       vue-router: 4.0.3_vue@3.0.5
     specifiers:
       '@ream/fetch': workspace:*
       '@vueuse/head': ^0.2.3
+      mitt: ^2.1.0
       vue: ^3.0.5
       vue-router: ^4.0.3
   packages/create-ream-app:
@@ -3643,6 +3645,10 @@ packages:
   /minimist/1.2.5:
     resolution:
       integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  /mitt/2.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==
   /mixin-deep/1.3.2:
     dependencies:
       for-in: 1.0.2

--- a/website/src/css/main.css
+++ b/website/src/css/main.css
@@ -1,5 +1,3 @@
-/* purgecss start ignore */
-
 :root {
   --header-height: 60px;
   --sidebar-width: 20rem;
@@ -76,5 +74,3 @@ body[data-no-scroll] {
 .markdown-body ul li {
   @apply mb-1;
 }
-
-/* purgecss end ignore */

--- a/website/src/enhance-app.ts
+++ b/website/src/enhance-app.ts
@@ -1,0 +1,5 @@
+export const onCreatedApp = ({ router }) => {
+  router.afterEach((to) => {
+    to.meta.transitionName = 'fade'
+  })
+}

--- a/website/src/enhance-app.ts
+++ b/website/src/enhance-app.ts
@@ -1,5 +1,0 @@
-export const onCreatedApp = ({ router }) => {
-  router.afterEach((to) => {
-    to.meta.transitionName = 'fade'
-  })
-}

--- a/website/src/pages/docs/[...slug].vue
+++ b/website/src/pages/docs/[...slug].vue
@@ -37,7 +37,6 @@ export default defineComponent({
 
   setup() {
     const preloadData = usePageData()
-
     const title = computed(() => {
       return `${preloadData.value.title} - Ream Documentation`
     })


### PR DESCRIPTION
Closes #14 

Page transition works now, simply export a `transition` property or function in any page.

```js
export const transition = 'slide-fade'

export const transition = (to, from) => {
  return {
    name: 'fade'
  }
}
```